### PR TITLE
Run Unit Tests via Github Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,24 @@
+name: Run Unit Tests
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: swift-actions/setup-swift@v1
+        with:
+          swift-version: '5.5'
+      - name: Swift Version
+        run: swift --version
+      - name: Build
+        run: swift build
+      - name: Run tests
+        run: swift test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,8 +16,6 @@ jobs:
       - uses: swift-actions/setup-swift@v1
         with:
           swift-version: '5.5'
-      - name: Swift Version
-        run: swift --version
       - name: Build
         run: swift build
       - name: Run tests

--- a/Package.resolved
+++ b/Package.resolved
@@ -3,11 +3,11 @@
     "pins": [
       {
         "package": "HTTPStatusCodes",
-        "repositoryURL": "https://github.com/rhodgkins/SwiftHTTPStatusCodes.git",
+        "repositoryURL": "https://github.com/jaderfeijo/SwiftHTTPStatusCodes.git",
         "state": {
-          "branch": null,
-          "revision": "a2c4f5f645dec3a5614ff82e391f44e22d778f87",
-          "version": "3.3.2"
+          "branch": "master",
+          "revision": "03e37747e84f2cd9d291a1681b6ddcf416281710",
+          "version": null
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -12,8 +12,9 @@ let package = Package(
 	dependencies: [
 		.package(
 			name: "HTTPStatusCodes",
-			url: "https://github.com/rhodgkins/SwiftHTTPStatusCodes.git",
-			.upToNextMajor(from: "3.3.0"))
+			url: "https://github.com/jaderfeijo/SwiftHTTPStatusCodes.git",
+			.branch("master")
+		)
 	],
 	targets: [
 		.target(

--- a/Sources/HTTPLib/DataProvider.swift
+++ b/Sources/HTTPLib/DataProvider.swift
@@ -1,6 +1,10 @@
 import Foundation
 import HTTPStatusCodes
 
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
 public typealias DataProviderClosure = (DataProviderResponse) -> Void
 
 public struct DataProviderRequest {

--- a/Sources/HTTPLib/HTTPDataProvider.swift
+++ b/Sources/HTTPLib/HTTPDataProvider.swift
@@ -1,6 +1,10 @@
 import Foundation
 import HTTPStatusCodes
 
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
 /// HTTP Data Provider.
 ///
 /// This class provides data via HTTP to it's consumers.

--- a/Tests/HTTPLibTests/XCTestManifests.swift
+++ b/Tests/HTTPLibTests/XCTestManifests.swift
@@ -1,9 +1,0 @@
-import XCTest
-
-#if !canImport(ObjectiveC)
-public func allTests() -> [XCTestCaseEntry] {
-    return [
-        testCase(HTTPLibTests.allTests),
-    ]
-}
-#endif

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1,6 +1,0 @@
-import XCTest
-import HTTPLibTests
-
-var tests = [XCTestCaseEntry]()
-tests += HTTPLibTests.allTests()
-XCTMain(tests)


### PR DESCRIPTION
## Description

This PR adds a new **test** action which builds and runs unit tests for this project using Github Actions.

The unit tests are run every time commits are merged/pushed into the `main` branch, as well as when pull requests are opened targeting the `main` branch.

## Observations

Because the test action runs using Github Action's `ubuntu-latest` image, the project had to be slightly modified so it compiles under linux.

The following changes were made:
* Updated `SwiftHTTPStatusCodes` dependency to point to a fork that also compiles under linux
* Sprinkled `import FoundationNetworking` statements where networking dependencies were used since that is the Swift module to use under linux when using `URL` & `URLSession` as well as other networking libraries which are normally found under `Foundation` on macOS.