### PR TITLE
Implement HTTP Provider Unit Tests

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcschemes/HTTPLib.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/HTTPLib.xcscheme
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1340"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "HTTPLib"
+               BuildableName = "HTTPLib"
+               BlueprintName = "HTTPLib"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "HTTPLibTests"
+               BuildableName = "HTTPLibTests"
+               BlueprintName = "HTTPLibTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "HTTPLibTests"
+               BuildableName = "HTTPLibTests"
+               BlueprintName = "HTTPLibTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "HTTPLib"
+            BuildableName = "HTTPLib"
+            BlueprintName = "HTTPLib"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Sources/HTTPLib/DataProvider.swift
+++ b/Sources/HTTPLib/DataProvider.swift
@@ -5,8 +5,10 @@ import HTTPStatusCodes
 import FoundationNetworking
 #endif
 
+/// A closure that passes a response to a sent request.
 public typealias DataProviderClosure = (DataProviderResponse) -> Void
 
+/// A request sent to a `DataProvider`
 public struct DataProviderRequest {
 	public let method: HTTPMethod
 	public let url: String
@@ -32,7 +34,6 @@ public enum DataProviderResponse {
 ///
 /// @since 1.0
 public protocol DataProvider {
-
 	/// Sends the specified request to the provider.
 	///
 	/// - parameter request: The request used to send/retrieve the data
@@ -43,7 +44,6 @@ public protocol DataProvider {
 }
 
 public extension DataProvider {
-
 	@available(macOS 10.15, *)
 	/// Sends the specified request to the provider.
 	/// - Parameter request: The request used to send/retrieve the data
@@ -62,6 +62,7 @@ public extension DataProvider {
 	}
 }
 
+/// The HTTP method to use for a given request.
 public enum HTTPMethod: String {
 	case get = "GET"
 	case head = "HEAD"

--- a/Sources/HTTPLib/HTTPDataProvider.swift
+++ b/Sources/HTTPLib/HTTPDataProvider.swift
@@ -7,15 +7,16 @@ import FoundationNetworking
 
 /// HTTP Data Provider.
 ///
-/// This class provides data via HTTP to it's consumers.
-public class HTTPDataProvider: DataProvider {
-
-	private let session: URLSession
+/// This class provides data via HTTP to its consumers.
+public class HTTPDataProvider {
+	let session: URLSession
 
 	public init(session: URLSession = .shared) {
 		self.session = session
 	}
+}
 
+extension HTTPDataProvider: DataProvider {
 	public func send(_ request: DataProviderRequest, callback: @escaping DataProviderClosure) throws {
 		let httpRequest = try URLRequest.from(
 			request: request)
@@ -33,33 +34,9 @@ public class HTTPDataProvider: DataProvider {
 	}
 }
 
-// MARK: - Private -
+// MARK: - Internal -
 
-private extension HTTPDataProvider {
-	func upload(_ request: URLRequest, body: Data, callback: @escaping DataProviderClosure) {
-		session.uploadTask(with: request, from: body) { data, response, error in
-			callback(
-				.mappedResponse(
-					from: data,
-					response: response,
-					error: error)
-			)
-		}.resume()
-	}
-
-	func download(_ request: URLRequest, callback: @escaping DataProviderClosure) {
-		session.dataTask(with: request) { data, response, error in
-			callback(
-				.mappedResponse(
-					from: data,
-					response: response,
-					error: error)
-			)
-		}.resume()
-	}
-}
-
-private extension DataProviderResponse {
+extension DataProviderResponse {
 	static func mappedResponse(from data: Data?, response: URLResponse?, error: Error?) -> Self {
 		guard error == nil else {
 			return .unreachable
@@ -81,12 +58,12 @@ private extension DataProviderResponse {
 	}
 }
 
-private extension URLRequest {
-	static func from(request: DataProviderRequest) throws -> URLRequest {
-		struct InvalidURLError: Swift.Error {
-			let url: String
-		}
+extension URLRequest {
+	struct InvalidURLError: Swift.Error {
+		let url: String
+	}
 
+	static func from(request: DataProviderRequest) throws -> URLRequest {
 		guard let url = URL(string: request.url) else {
 			throw InvalidURLError(url: request.url)
 		}
@@ -94,6 +71,33 @@ private extension URLRequest {
 		let urlRequest = NSMutableURLRequest(url: url)
 		urlRequest.httpMethod = request.method.rawValue
 		urlRequest.allHTTPHeaderFields = request.headers
+		urlRequest.httpBody = request.body
 		return urlRequest as URLRequest
+	}
+}
+
+// MARK: - Private -
+
+private extension HTTPDataProvider {
+	func upload(_ request: URLRequest, body: Data, callback respondWith: @escaping DataProviderClosure) {
+		session.uploadTask(with: request, from: body) { data, response, error in
+			respondWith(
+				.mappedResponse(
+					from: data,
+					response: response,
+					error: error)
+			)
+		}.resume()
+	}
+
+	func download(_ request: URLRequest, callback respondWith: @escaping DataProviderClosure) {
+		session.dataTask(with: request) { data, response, error in
+			respondWith(
+				.mappedResponse(
+					from: data,
+					response: response,
+					error: error)
+			)
+		}.resume()
 	}
 }

--- a/Sources/HTTPLib/HTTPDataProvider.swift
+++ b/Sources/HTTPLib/HTTPDataProvider.swift
@@ -37,30 +37,30 @@ public class HTTPDataProvider: DataProvider {
 
 private extension HTTPDataProvider {
 	func upload(_ request: URLRequest, body: Data, callback: @escaping DataProviderClosure) {
-		session.uploadTask(with: request, from: body) {
+		session.uploadTask(with: request, from: body) { data, response, error in
 			callback(
-				.from(
-					data: $0,
-					response: $1,
-					error: $2)
+				.mappedResponse(
+					from: data,
+					response: response,
+					error: error)
 			)
 		}.resume()
 	}
 
 	func download(_ request: URLRequest, callback: @escaping DataProviderClosure) {
-		session.dataTask(with: request) {
+		session.dataTask(with: request) { data, response, error in
 			callback(
-				.from(
-					data: $0,
-					response: $1,
-					error: $2)
+				.mappedResponse(
+					from: data,
+					response: response,
+					error: error)
 			)
 		}.resume()
 	}
 }
 
 private extension DataProviderResponse {
-	static func from(data: Data?, response: URLResponse?, error: Error?) -> Self {
+	static func mappedResponse(from data: Data?, response: URLResponse?, error: Error?) -> Self {
 		guard error == nil else {
 			return .unreachable
 		}

--- a/Tests/HTTPLibTests/HTTPDataProviderTests.swift
+++ b/Tests/HTTPLibTests/HTTPDataProviderTests.swift
@@ -1,6 +1,10 @@
 import XCTest
 @testable import HTTPLib
 
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
 class HTTPDataProviderTests: XCTestCase {
 	var configuration: URLSessionConfiguration!
 	var session: URLSession!

--- a/Tests/HTTPLibTests/HTTPDataProviderTests.swift
+++ b/Tests/HTTPLibTests/HTTPDataProviderTests.swift
@@ -1,0 +1,276 @@
+import XCTest
+@testable import HTTPLib
+
+class HTTPDataProviderTests: XCTestCase {
+	var configuration: URLSessionConfiguration!
+	var session: URLSession!
+	var sut: HTTPDataProvider!
+
+	override func setUpWithError() throws {
+		try super.setUpWithError()
+
+		configuration = URLSessionConfiguration.default
+		configuration.protocolClasses = [MockURLProtocol.self]
+		session = URLSession(configuration: configuration)
+		sut = HTTPDataProvider(session: session)
+	}
+
+	override func tearDownWithError() throws {
+		configuration = nil
+		session = nil
+		sut = nil
+
+		MockURLProtocol.requestHandler = nil
+
+		try super.tearDownWithError()
+	}
+}
+
+extension HTTPDataProviderTests {
+	func testSendInvalidRequest() throws {
+		let expectation = expectation(description: "request completed")
+
+		do {
+			let request = DataProviderRequest(
+				method: .get,
+				url: "   ",
+				headers: nil,
+				body: nil)
+			try sut.send(request) { _ in
+				XCTFail("Expected exception to be thrown")
+			}
+		} catch {
+			expectation.fulfill()
+		}
+
+		waitForExpectations(timeout: 1.0)
+	}
+
+	func testSendPostRequest() throws {
+		let expectation = expectation(description: "request completed")
+
+		MockURLProtocol.requestHandler = { request in
+			(
+				HTTPURLResponse(
+					url: URL(string: "test")!,
+					statusCode: 200,
+					httpVersion: nil,
+					headerFields: nil)!,
+				"response".data(using: .utf8)!
+			)
+		}
+
+		let request = DataProviderRequest(
+			method: .post,
+			url: "test",
+			headers: nil,
+			body: "body".data(using: .utf8)!)
+		try sut.send(request) { response in
+			XCTAssertEqual(response, .success(data: "response".data(using: .utf8)!))
+			expectation.fulfill()
+		}
+
+		waitForExpectations(timeout: 1.0)
+	}
+
+	func testSendGetRequest() throws {
+		let expectation = expectation(description: "request completed")
+
+		MockURLProtocol.requestHandler = { request in
+			(
+				HTTPURLResponse(
+					url: URL(string: "test")!,
+					statusCode: 200,
+					httpVersion: nil,
+					headerFields: nil)!,
+				"response".data(using: .utf8)!
+			)
+		}
+
+		let request = DataProviderRequest(
+			method: .get,
+			url: "test",
+			headers: nil,
+			body: nil)
+		try sut.send(request) { response in
+			XCTAssertEqual(response, .success(data: "response".data(using: .utf8)!))
+			expectation.fulfill()
+		}
+
+		waitForExpectations(timeout: 1.0)
+	}
+
+	func testSendTimeout() throws {
+		let expectation = expectation(description: "request completed")
+
+		MockURLProtocol.requestHandler = { _ in
+			throw URLError(URLError.timedOut)
+		}
+
+		let request = DataProviderRequest(
+			method: .get,
+			url: "test",
+			headers: nil,
+			body: nil)
+		try sut.send(request) { response in
+			XCTAssertEqual(response, .unreachable)
+			expectation.fulfill()
+		}
+
+		waitForExpectations(timeout: 1.0)
+	}
+}
+
+extension HTTPDataProviderTests {
+	func testDataProviderResponseMappedResponseError() throws {
+		struct MockError: Swift.Error { }
+		XCTAssertEqual(
+			DataProviderResponse.mappedResponse(
+				from: nil,
+				response: nil,
+				error: MockError()),
+			.unreachable)
+	}
+
+	func testDataProviderResponseMappedResponseNotHTTPResponse() throws {
+		XCTAssertEqual(
+			DataProviderResponse.mappedResponse(
+				from: "some-data".data(using: .utf8)!,
+				response: URLResponse(
+					url: .init(string: "test-url")!,
+					mimeType: nil,
+					expectedContentLength: 0,
+					textEncodingName: nil),
+				error: nil),
+			.error(
+				code: nil,
+				data: "some-data".data(using: .utf8)!)
+		)
+	}
+
+	func testDataProviderResponseMappedResponseHTTPErrorNoStatusCode() throws {
+		XCTAssertEqual(
+			DataProviderResponse.mappedResponse(
+				from: "some-data".data(using: .utf8)!,
+				response: HTTPURLResponse(
+					url: .init(string: "test-url")!,
+					statusCode: 0,
+					httpVersion: nil,
+					headerFields: nil),
+				error: nil),
+			.error(
+				code: nil,
+				data: "some-data".data(using: .utf8)!)
+		)
+	}
+
+	func testDataProviderResponseMappedResponseHTTPError() throws {
+		XCTAssertEqual(
+			DataProviderResponse.mappedResponse(
+				from: "some-data".data(using: .utf8)!,
+				response: HTTPURLResponse(
+					url: .init(string: "test-url")!,
+					statusCode: 404,
+					httpVersion: nil,
+					headerFields: nil),
+				error: nil),
+			.error(
+				code: .notFound,
+				data: "some-data".data(using: .utf8)!)
+		)
+	}
+
+	func testDataProviderResponseMappedResponseSuccess() throws {
+		XCTAssertEqual(
+			DataProviderResponse.mappedResponse(
+				from: "some-data".data(using: .utf8)!,
+				response: HTTPURLResponse(
+					url: .init(string: "test-url")!,
+					statusCode: 200,
+					httpVersion: nil,
+					headerFields: nil),
+				error: nil),
+			.success(
+				data: "some-data".data(using: .utf8)!)
+		)
+	}
+}
+
+extension HTTPDataProviderTests {
+	func testURLRequestFromDataProviderRequestSuccess() throws {
+		let request = DataProviderRequest(
+			method: .get,
+			url: "http://test/test",
+			headers: ["key": "value"],
+			body: "test".data(using: .utf8)!)
+		let urlRequest = try URLRequest.from(
+			request: request)
+
+		XCTAssertEqual(urlRequest.httpMethod, "GET")
+		XCTAssertEqual(urlRequest.url, URL(string: "http://test/test")!)
+		XCTAssertEqual(urlRequest.allHTTPHeaderFields, ["key": "value"])
+		XCTAssertEqual(urlRequest.httpBody, "test".data(using: .utf8)!)
+	}
+
+	func testURLRequestFromDataProviderRequestInvalidURL() throws {
+		let request = DataProviderRequest(
+			method: .get,
+			url: "   ", // invalid url
+			headers: ["key": "value"],
+			body: "test".data(using: .utf8)!)
+
+		do {
+			_ = try URLRequest.from(
+				request: request)
+			XCTFail("Expected exception to be thrown")
+		} catch {
+			XCTAssert(error is URLRequest.InvalidURLError)
+			XCTAssertEqual((error as? URLRequest.InvalidURLError)?.url, "   ")
+		}
+	}
+}
+
+// MARK: - Private -
+
+private extension HTTPDataProviderTests {
+	class MockURLProtocol: URLProtocol {
+		typealias ResponseProvider = (URLRequest) throws -> (HTTPURLResponse, Data?)
+
+		static var requestHandler: ResponseProvider!
+
+		override class func canInit(with request: URLRequest) -> Bool {
+			return true
+		}
+
+		override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+			return request
+		}
+
+		override func startLoading() {
+			do {
+				let (response, data) = try Self.requestHandler!(request)
+
+				client?.urlProtocol(
+					self,
+					didReceive: response,
+					cacheStoragePolicy: .notAllowed)
+
+				if let data = data {
+					client?.urlProtocol(
+						self,
+						didLoad: data)
+				}
+
+				client?.urlProtocolDidFinishLoading(self)
+			} catch {
+				client?.urlProtocol(
+					self,
+					didFailWithError: error)
+			}
+		}
+
+		override func stopLoading() {
+			//
+		}
+	}
+}


### PR DESCRIPTION
## Description

This PR substantially extends the unit test coverage of the project to include the `HTTPDataProvider` implementation of the `DataProvider` protocol