### PR TITLE
Update swift tools version to 5.5

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -5,7 +5,7 @@
         "package": "HTTPStatusCodes",
         "repositoryURL": "https://github.com/jaderfeijo/SwiftHTTPStatusCodes.git",
         "state": {
-          "branch": "master",
+          "branch": null,
           "revision": "03e37747e84f2cd9d291a1681b6ddcf416281710",
           "version": null
         }

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.5
 
 import PackageDescription
 
@@ -7,19 +7,22 @@ let package = Package(
 	products: [
 		.library(
 			name: "HTTPLib",
-			targets: ["HTTPLib"]),
+			targets: ["HTTPLib"])
 	],
 	dependencies: [
 		.package(
-			name: "HTTPStatusCodes",
 			url: "https://github.com/jaderfeijo/SwiftHTTPStatusCodes.git",
-			.branch("master")
-		)
+			revision: "03e37747e84f2cd9d291a1681b6ddcf416281710")
 	],
 	targets: [
 		.target(
 			name: "HTTPLib",
-			dependencies: ["HTTPStatusCodes"]),
+			dependencies: [
+				.product(
+					name: "HTTPStatusCodes",
+					package: "SwiftHTTPStatusCodes")
+			]
+		),
 		.testTarget(
 			name: "HTTPLibTests",
 			dependencies: ["HTTPLib"]),


### PR DESCRIPTION
## Description

This PR updates the swift tools version to 5.5 for this package. It also pins the `SwiftHTTPStatusCodes` library dependency to a specific commit.