### PR TITLE
Update SwiftHTTPStatusCodes to use version 3.4.0

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/jaderfeijo/SwiftHTTPStatusCodes.git",
         "state": {
           "branch": null,
-          "revision": "03e37747e84f2cd9d291a1681b6ddcf416281710",
-          "version": null
+          "revision": "8f5e0b8002820fadbabcce5523ebec46ccfe711b",
+          "version": "3.4.0"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
 	dependencies: [
 		.package(
 			url: "https://github.com/jaderfeijo/SwiftHTTPStatusCodes.git",
-			revision: "03e37747e84f2cd9d291a1681b6ddcf416281710")
+			.upToNextMajor(from: "3.4.0"))
 	],
 	targets: [
 		.target(


### PR DESCRIPTION
## Description

This PR updates the `SwiftHTTPStatusCodes` library to version `3.4.0`